### PR TITLE
Add missing space between words

### DIFF
--- a/site/office/api/views/index.py
+++ b/site/office/api/views/index.py
@@ -250,7 +250,7 @@ class MPOpeningSentence(Module):
         if self.office.date.date.weekday() == 0:
             return {
                 "sentence": "I was glad when they said unto me, “We will go into the house of the Lord.",
-                "traditional": "I was glad when they said unto me, We will go into the house ofthe Lord.",
+                "traditional": "I was glad when they said unto me, We will go into the house of the Lord.",
                 "citation": "PSALM 122:1",
             }
 


### PR DESCRIPTION
Fix minor typo to add a space between "of" and "the" in the "traditional" language.